### PR TITLE
Fix dense project list overflow and dialog header layout on mobile

### DIFF
--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -13,7 +13,7 @@ const { project, dense = false } = defineProps<{
   dense?: boolean;
 }>();
 
-const CARD_CLASS = "flex flex-col border border-border rounded-lg bg-white/30 hover:scale-102 hover:bg-white/50 hover:shadow-lg transition-all duration-300";
+const CARD_CLASS = "flex flex-col min-w-0 border border-border rounded-lg bg-white/30 hover:scale-102 hover:bg-white/50 hover:shadow-lg transition-all duration-300";
 </script>
 
 <template>
@@ -27,13 +27,13 @@ const CARD_CLASS = "flex flex-col border border-border rounded-lg bg-white/30 ho
         <div class="flex flex-col gap-3 cursor-pointer text-left" role="button" tabindex="0">
           <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
             <h4 class="text-xl sm:text-2xl font-bold">{{ project.name }}</h4>
-            <div class="flex items-center gap-2 flex-shrink-0">
+            <div class="flex items-center gap-2 flex-wrap flex-shrink-0">
               <Badge v-if="project.status" :variant="getStatusVariant(project.status)">{{ firstUp(project.status) }}</Badge>
               <Badge v-if="project.category" :variant="getCategoryVariant(project.category)">{{ project.category }}</Badge>
             </div>
           </div>
 
-          <div class="flex items-center gap-2 text-sm text-muted-foreground min-w-46">
+          <div class="flex items-center gap-2 text-sm text-muted-foreground min-w-0">
             <Calendar :size="16" />
             <span class="max-w-full truncate">{{ formatDateRange(project.dateStart, project.dateEnd, true) }}</span>
           </div>

--- a/src/components/ProjectCardBody.vue
+++ b/src/components/ProjectCardBody.vue
@@ -21,20 +21,29 @@ const COMPANY_TOOLTIP = "Firma lub kontekst, w ramach którego zrealizowano proj
 <template>
   <div class="flex flex-col gap-4">
     <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
-      <h4 class="text-xl sm:text-2xl font-bold" :id="project.id">{{ project.name }}</h4>
-      <div class="flex items-center gap-2 flex-shrink-0">
-        <Tooltip v-if="project.status">
-          <TooltipTrigger as-child>
-            <Badge :variant="getStatusVariant(project.status)">{{ firstUp(project.status) }}</Badge>
-          </TooltipTrigger>
-          <TooltipContent>{{ getStatusDescription(project.status) }}</TooltipContent>
-        </Tooltip>
-        <Tooltip v-if="project.category">
-          <TooltipTrigger as-child>
-            <Badge :variant="getCategoryVariant(project.category)">{{ project.category }}</Badge>
-          </TooltipTrigger>
-          <TooltipContent>{{ getCategoryDescription(project.category) }}</TooltipContent>
-        </Tooltip>
+      <h4
+        class="text-xl sm:text-2xl font-bold"
+        :class="{ 'order-2 sm:order-none': !!$slots.actions }"
+        :id="project.id"
+      >{{ project.name }}</h4>
+      <div
+        class="flex items-center gap-2 flex-shrink-0"
+        :class="{ 'order-1 sm:order-none justify-between w-full sm:w-auto': !!$slots.actions }"
+      >
+        <div class="flex items-center gap-2 flex-wrap">
+          <Tooltip v-if="project.status">
+            <TooltipTrigger as-child>
+              <Badge :variant="getStatusVariant(project.status)">{{ firstUp(project.status) }}</Badge>
+            </TooltipTrigger>
+            <TooltipContent>{{ getStatusDescription(project.status) }}</TooltipContent>
+          </Tooltip>
+          <Tooltip v-if="project.category">
+            <TooltipTrigger as-child>
+              <Badge :variant="getCategoryVariant(project.category)">{{ project.category }}</Badge>
+            </TooltipTrigger>
+            <TooltipContent>{{ getCategoryDescription(project.category) }}</TooltipContent>
+          </Tooltip>
+        </div>
         <slot name="actions" />
       </div>
     </div>

--- a/src/components/navigation/NavBar.astro
+++ b/src/components/navigation/NavBar.astro
@@ -32,7 +32,7 @@ const isActive = (link: Link) => {
   <BackgroundBar class="absolute left-0 right-0 top-4" />
 
   <nav class="nav-bar container w-full max-w-screen-sm mx-auto backdrop-blur-xs">
-    <ul class="w-full px-2 z-10 flex flex-row items-center justify-evenly gap-2 text-xl font-black">
+    <ul class="w-full px-2 z-10 flex flex-row items-center justify-evenly gap-1 sm:gap-2 text-base sm:text-xl font-black">
       {links.map((link) => (
         <li>
           <a
@@ -74,7 +74,7 @@ const isActive = (link: Link) => {
   }
 
   .nav-bar a {
-    @apply px-2 py-4 text-black hover:text-white/70 transition-colors tracking-wider;
+    @apply px-1 py-4 sm:px-2 text-black hover:text-white/70 transition-colors tracking-wider;
     text-shadow: rgba(200, 255, 200, 0.8) 1px 2px 4px;
     transition: all linear 0.3s;
 

--- a/src/components/sections/ProjectSection.vue
+++ b/src/components/sections/ProjectSection.vue
@@ -85,8 +85,8 @@ const hasActiveFilters = computed(() =>
         name="project"
         tag="ul"
         :class="[
-          'grid gap-6',
-          dense ? 'grid-cols-2' : 'grid-cols-1'
+          'grid',
+          dense ? 'grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6' : 'grid-cols-1 gap-6'
         ]"
       >
         <ProjectCard


### PR DESCRIPTION
Dense grid now stays single-column below sm, matching the reduced gap;
a min-w-46 typo (was forcing a 184px minimum) and missing flex-wrap
were causing dates/badges to spill past the card edge on narrow
screens. In the project detail dialog, badges and the close button now
sit above the title (badges left, close button right) on mobile only;
desktop layout is unchanged.